### PR TITLE
fix: use regional endpoint for service datasource

### DIFF
--- a/konnect/data_source_service.go
+++ b/konnect/data_source_service.go
@@ -102,7 +102,7 @@ func dataSourceServiceRead(ctx context.Context, d *schema.ResourceData, m interf
 	if ok {
 		requestQuery[client.FilterNameEquals] = []string{name.(string)}
 	}
-	body, err := c.HttpRequest(ctx, false, http.MethodGet, requestPath, requestQuery, nil, &bytes.Buffer{})
+	body, err := c.HttpRequest(ctx, true, http.MethodGet, requestPath, requestQuery, nil, &bytes.Buffer{})
 	if err != nil {
 		d.SetId("")
 		return diag.FromErr(err)


### PR DESCRIPTION
Datasource for service uses global endpoint but it should use a regional endpoint. Otherwise, it results in error 500.

If you accept this PR, can you please also release a fix version ?

Thanks